### PR TITLE
Request Cache implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ In homebridge's `config.json` you need to specify a platform for homebridge-hue:
       "groups": false,
       "sensors": false,
       "schedules": false,
-      "rules": false
+      "rules": false,
+      "maxopenrequests": 5
     }
   ]
 ```
@@ -97,6 +98,7 @@ The following parameters modify homebridge-hue's behaviour:
 - `sensors`: Flag whether to expose Hue bridge sensors to Homekit.  Default: `false`;
 - `schedules`: Flag whether to expose Hue bridge schedules to Homekit.  Default: `false`;
 - `rules`: Flag whether to expose Hue bridge rules to Homekit.  Default: `false`.
+- `maxopenrequests`: Number of concurrent network requests that Homebridge will make to the Hue bridge. 1st Gen Hue bridges will experience errors (such as ```ECONNRESET```) if more than 5 requests are open at a time. Default: `5` 
 
 ## Caveats
 - The homebridge-hue plug-in is a hobby project of mine, provided as-is, with no warranty whatsoever.  I've been running it successfully at my home for months, but your mileage might vary.  Please report any issues on GitHub.

--- a/lib/HueBridge.js
+++ b/lib/HueBridge.js
@@ -11,6 +11,7 @@ let fs = require("fs");
 let os = require("os");
 let request = require("request");
 let util = require("util");
+let deferred = require("deferred");
 
 let HueLightModule = require("./HueLight");
 let HueSensorModule = require("./HueSensor");
@@ -51,11 +52,16 @@ function HueBridge(platform, host) {
   this.sensors = {};
   this.schedules = {};
   this.rules = {};
+
+  this.requestCache = [];
+  this.requestCacheRunning = false;
+  this.openRequestsCount = 0;
+  this.requestInterval = null;
 }
 
 HueBridge.prototype.getServices = function() {
   return [this.infoService];
-}
+};
 
 HueBridge.prototype.accessories = function(callback) {
   var accessoryList = [];
@@ -104,7 +110,7 @@ HueBridge.prototype.accessories = function(callback) {
     }
     return callback(accessoryList);
   }.bind(this));
-}
+};
 
 HueBridge.prototype.pressLinkButton = function(resolve) {
   this.request("post", "/", "{\"devicetype\":\"homebridge-hue#" + os.hostname() + "\"}")
@@ -129,7 +135,7 @@ HueBridge.prototype.pressLinkButton = function(resolve) {
       this.pressLinkButton(resolve);
     }.bind(this), this.platform.config.timeout)
   }.bind(this));
-}
+};
 
 HueBridge.prototype.createUser = function() {
   if (this.username) {
@@ -139,7 +145,7 @@ HueBridge.prototype.createUser = function() {
   return new Promise(function(resolve, reject) {
     this.pressLinkButton(resolve);
   }.bind(this));
-}
+};
 
 HueBridge.prototype.mapLights = function(f) {
   if (!this.platform.config.lights) {
@@ -152,7 +158,7 @@ HueBridge.prototype.mapLights = function(f) {
       }
     }
   }.bind(this));
-}
+};
 
 HueBridge.prototype.mapGroups = function(f) {
   if (!this.platform.config.groups) {
@@ -168,7 +174,7 @@ HueBridge.prototype.mapGroups = function(f) {
       }
     }
   }.bind(this)));
-}
+};
 
 HueBridge.prototype.mapSensors = function(f) {
   if (!this.platform.config.sensors) {
@@ -179,7 +185,7 @@ HueBridge.prototype.mapSensors = function(f) {
       f(id, obj[id]);
     }
   }.bind(this));
-}
+};
 
 HueBridge.prototype.mapSchedules = function(f) {
   if (!this.platform.config.schedules) {
@@ -190,7 +196,7 @@ HueBridge.prototype.mapSchedules = function(f) {
       f(id, obj[id])
     }
   }.bind(this));
-}
+};
 
 HueBridge.prototype.mapRules = function(f) {
   if (!this.platform.config.rules) {
@@ -201,7 +207,7 @@ HueBridge.prototype.mapRules = function(f) {
       f(id, obj[id])
     }
   }.bind(this));
-}
+};
 
 // ===== Heartbeat =======================================================================
 
@@ -238,7 +244,7 @@ HueBridge.prototype.heartbeat = function() {
   }.bind(this)))
   .catch(function (err) {
   }.bind(this));
-}
+};
 
 // ===== Homekit Events ==================================================================
 
@@ -268,58 +274,87 @@ HueBridge.prototype.identify = function(callback) {
     this.log.error(err);
   }.bind(this));
   return callback();
-}
+};
 
 // ===== Bridge Communication ============================================================
 
 // Send request to Philips Hue bridge.
 HueBridge.prototype.request = function(method, resource, body) {
-  return new Promise(function(resolve, reject) {
-    var requestObj = {
-      method: method,
-      url: this.url + resource,
-      timeout: this.platform.config.timeout
+    let defPromise = deferred();
+    let requestCacheItem = {
+        method: method,
+        resource: resource,
+        body: body,
+        defPromise: defPromise
     };
-    var requestString = method + " " + resource;
-    if (body) {
-      requestObj.body = body;
-      requestString += " '" + body + "'";
+    this.log.debug("%s: hue bridge adding request to cache: %s", this.name, resource);
+    this.requestCache.push(requestCacheItem);
+    if (this.requestInterval === null) {
+        this.log.debug("%s: hue bridge starting request cache poling", this.name);
+        this.requestInterval = setInterval(this.runCache.bind(this), 100);
     }
-    this.log.debug("%s: hue bridge request: %s", this.name, requestString);
-    request(requestObj, function(err, response, responseBody) {
-      if (err) {
-        if (err.code === "ECONNRESET") {
-          this.log.debug("%s: hue bridge communication error %s - retrying in 300ms", this.name, err.code);
-          setTimeout(function () {
-            resolve(this.request(method, resource, body));
-          }.bind(this), 300);
-          return;
+    return defPromise.promise;
+};
+
+// Handle Hue requests cache
+HueBridge.prototype.runCache = function() {
+    if (this.requestCacheRunning) {
+        return;
+    } else {
+        this.requestCacheRunning = true;
+        if (this.requestCache.length > 0 && this.openRequestsCount < this.platform.config.maxopenrequests) {
+            let availableRequestSlots = (this.platform.config.maxopenrequests - this.openRequestsCount);
+            availableRequestSlots = (this.requestCache.length < availableRequestSlots) ?
+                this.requestCache.length : availableRequestSlots;
+            this.log.debug("%s: available request slots: %s", this.name, availableRequestSlots);
+
+            for (var i = 0; i < availableRequestSlots; i++) {
+                let cacheItem = this.requestCache.shift();
+                this.openRequestsCount++;
+                let requestObj = {
+                    method: cacheItem.method,
+                    url: this.url + cacheItem.resource,
+                    timeout: this.platform.config.timeout
+                };
+                var requestString = cacheItem.method + " " + cacheItem.resource;
+                if (cacheItem.body) {
+                    requestObj.body = cacheItem.body;
+                    requestString += " '" + cacheItem.body + "'";
+                }
+                cacheItem.name = requestString;
+                this.log.debug("%s: hue bridge request: %s", this.name, requestString);
+                request(requestObj, function (err, response, responseBody) {
+                    this.openRequestsCount--;
+                    if (err) {
+                        this.log.error("%s: hue bridge communication error %s", this.name, err);
+                        return cacheItem.defPromise.reject(err);
+                    }
+                    if (response.statusCode != 200) {
+                        this.log.error("%s: hue bridge status %s", this.name, response.statusCode);
+                        return cacheItem.defPromise.reject(err);
+                    }
+                    // this.log.debug("%s: hue bridge response: %s", this.name, responseBody);
+                    var obj;
+                    try {
+                        obj = JSON.parse(responseBody);
+                    } catch (e) {
+                        this.log.error("%s: hue bridge returned invalid json (%s)", this.name, e);
+                        return cacheItem.defPromise.reject(e);
+                    }
+                    if (util.isArray(obj)) {
+                        for (let id in obj) {
+                            let e = obj[id].error;
+                            if (e) {
+                                this.log.error("%s: hue bridge error %d: %s", this.name, e.type, e.description);
+                                return cacheItem.defPromise.reject(e.type);
+                            }
+                        }
+                    }
+                    this.log.debug("%s: hue bridge request resolved: %s", this.name, cacheItem.name);
+                    return cacheItem.defPromise.resolve(obj);
+                }.bind(this));
+            }
         }
-        this.log.error("%s: hue bridge communication error %s", this.name, err.code);
-        return reject(err.code);
-      }
-      if (response.statusCode != 200) {
-        this.log.error("%s: hue bridge status %s", this.name, response.statusCode);
-        return reject(response.statusCode);
-      }
-      // this.log.debug("%s: hue bridge response: %s", this.name, responseBody);
-      var obj;
-      try {
-        obj = JSON.parse(responseBody);
-      } catch(e) {
-        this.log.error("%s: hue bridge returned invalid json (%s)", this.name, e);
-        return reject(e);
-      }
-      if (util.isArray(obj)) {
-        for (let id in obj) {
-	        let e = obj[id].error;
-	        if (e) {
-	           this.log.error("%s: hue bridge error %d: %s", this.name, e.type, e.description);
-             return reject(e.type);
-	        }
-        }
-      }
-      return resolve(obj);
-    }.bind(this));
-  }.bind(this));
-}
+        this.requestCacheRunning = false;
+    }
+};

--- a/lib/HuePlatform.js
+++ b/lib/HuePlatform.js
@@ -81,7 +81,8 @@ function HuePlatform(log, config, api) {
     groups: config["groups"] || false,
     sensors: config["sensors"] || false,
     schedules: config["schedules"] || false,
-    rules: config["rules"] || false
+    rules: config["rules"] || false,
+    maxopenrequests: config["maxopenrequests"] || 5
   };
   this.bridges = [];
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "homebridge-hue",
   "dependencies": {
-    "request": "^2.65.0"
+    "request": "^2.65.0",
+    "deferred": "^0.7.5"
   },
   "description": "Homebridge plug-in for Philips Hue",
   "engines": {
@@ -11,7 +12,7 @@
   "keywords": [
     "homebridge-plugin"
   ],
-  "version": "0.0.12",
+  "version": "0.0.13",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
* In order to address network errors, implemented a request cache that limits open http requests to a configurable maximum (defaults to 5).
  * This eliminates network concurrency errors (such as ECONNRESET) on 1st Gen Hue bridges.
* Added new configuration property _maxopenrequests_ and added an explanation of the property in README.md.
* The "ECONNRESET" handling in 0.0.12 was removed, since the request cache prevents those errors from occurring.
* Added ```deferred``` node module needed to create deferred promises for the request cache.
* Updated version number to 0.0.13.