### PR TITLE
Support faulty OSRAM firmware and Osram Lightify PAR16 Tunable White

### DIFF
--- a/lib/HueLight.js
+++ b/lib/HueLight.js
@@ -313,6 +313,7 @@ HueLight.prototype.setConfig = function() {
   this.config.manufacturer = this.obj.manufacturername;
   this.config.model = this.obj.modelid;
   this.config.serialNumber = this.obj.uniqueid.split('-')[0];
+  this.config.softwareVersion = this.obj.swversion;
 
   switch (this.config.manufacturer) {
     case 'Philips':
@@ -375,10 +376,19 @@ HueLight.prototype.setConfig = function() {
       }
       break;
     case 'OSRAM':
+
+     switch (this.config.softwareVersion) {
+         case 'V1.03.07':
+           this.config.faultyOsramFW = true;
+         default:
+           break;
+      }
+ 
       switch (this.config.model) {
         case 'Plug - LIGHTIFY':
         case 'Plug 01':
           return;
+        case 'PAR16 50 TW':
         case 'Classic B40 TW - LIGHTIFY':
           this.config.maxCT = 370;
           return;
@@ -648,6 +658,11 @@ HueLight.prototype.setOn = function(on, callback) {
   );
   this.hk.on = on;
   const newOn = this.hk.on ? true : false;
+ 
+  if (this.config.faultyOsramFW) {
+    this.request('transitiontime', 0);
+  }
+
   this.request('on', newOn);
   return callback();
 };
@@ -663,6 +678,11 @@ HueLight.prototype.setAnyOn = function(on, callback) {
   );
   this.hk.on = on;
   const newOn = this.hk.on ? true : false;
+
+  if (this.config.faultyOsramFW) {
+    this.request('transitiontime', 0);
+  }
+
   this.request('on', newOn);
   return callback();
 };


### PR DESCRIPTION
- Patch for faulty Osram Firmware version 1.03.07    
- added support for "Osram Lightify PAR16 Tunable White"