### PR TITLE
Fixed node version check

### DIFF
--- a/lib/HuePlatform.js
+++ b/lib/HuePlatform.js
@@ -508,11 +508,7 @@ function HuePlatform(log, config, api) {
     '%s v%s, node %s, homebridge v%s', packageConfig.name,
     packageConfig.version, process.version, homebridgeVersion
   );
-  if (process.version != 'v' + packageConfig.engines.node) {
-    this.log.warn(
-      'warning: not using recommended node v%s LTS', packageConfig.engines.node
-    );
-  }
+  // nodeVersion is checked by homebridge
   // homebridgeVersion is checked by homebridge
   this.log.debug('config.json: %j', config);
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "engines": {
     "deconz": "2.04.80",
     "homebridge": "0.4.28",
-    "node": "6.11.3"
+    "node": ">=6.11.3"
   },
   "dependencies": {
     "deferred": "^0.7.8",


### PR DESCRIPTION
The node version check is causing issues and will prevent this plugin working on any version of node later than `6.11.3` when the next version of homebridge is released due https://github.com/nfarina/homebridge/pull/1541.

Running on any version of node greater than 6.11.3 will throw this error:

```
[2017-10-12 22:43:16] ====================
[2017-10-12 22:43:16] ERROR LOADING PLUGIN homebridge-hue:
[2017-10-12 22:43:16] Error: Plugin /homebridge/node_modules/homebridge-hue requires Node version of 6.11.3 which does not satisfy the current Node version of v8.7.0. You may need to upgrade your installation of Node.
```

The current version check also prevents the package being installed using the `yarn` package manager:

```
/homebridge # yarn add homebridge-hue
yarn add v1.2.0
error homebridge-hue@0.5.34: The engine "node" is incompatible with this module. Expected version "6.11.3".
error Found incompatible module
```

https://github.com/ebaauw/homebridge-hue/blob/b74732615bdeae08c8e2c729375ffbe80d09eec7/package.json#L22

I have changed this line to:

```
"node" : ">=6.11.3"
```

I have also removed this version check, since the next release of homebridge is going to take care of this:

https://github.com/ebaauw/homebridge-hue/blob/b74732615bdeae08c8e2c729375ffbe80d09eec7/lib/HuePlatform.js#L511-L515