### PR TITLE
Support for NXP-based lights

### DIFF
--- a/lib/HueLight.js
+++ b/lib/HueLight.js
@@ -320,6 +320,17 @@ HueLight.prototype.setConfig = function() {
   this.config.ignoreReachable = !this.bridge.platform.config.wallSwitch;
 
   switch (this.config.manufacturer) {
+    // NXP ZLL Lights
+    // See: https://github.com/peeveeone/ZLL_Lights
+    case 'Pee':
+     switch (this.config.model) {
+       case 'PeeVeeOne':
+         this.config.subtype = this.obj.uniqueid.split('-')[1];
+         return;
+       default:
+         break;
+     }
+     break;
     case 'Philips':
       // Color gamut per light model.
       // See: http://www.developers.meethue.com/documentation/supported-lights


### PR DESCRIPTION
Added support for custom/DIY NXP-based lights (https://github.com/peeveeone/ZLL_Lights)