### PR TITLE
Add support for ShenZen HOMA controllers

### DIFF
--- a/lib/HueLight.js
+++ b/lib/HueLight.js
@@ -590,6 +590,18 @@ HueLight.prototype.setConfig = function() {
          break;
      }
      break;
+    case 'ShenZhen_Homa':
+      switch (this.config.model) {
+        case 'HOMA1001':
+          this.config.subtype = this.obj.uniqueid.split('-')[1];
+          return;
+        case 'HOMA1002':
+        case 'HOMA1003':
+        case 'HOMA1004':
+          return;
+        default:
+          break;
+      }
     default:
       break;
   }


### PR DESCRIPTION
There are two models: one line voltage dimmer (brightness) and a
configurable 24V four-channel PWM controller. Depending on the DIP
switches on the RGBW controller, it appears as a single brightness,
color temperature, or extended color device; or as a combination color
and brightness device (RGBW).

They are sold in Germany through Amazon:
* https://www.amazon.de/gp/product/B076KPQWFW 230V
* https://www.amazon.de/gp/product/B076K6VJ8G 24V RGBW