### PR TITLE
Remove brightness characteristic from Busch Jaeger On/Off wall switches

### DIFF
--- a/lib/HueLight.js
+++ b/lib/HueLight.js
@@ -20,6 +20,12 @@ const defaultGamut = {
 
 const knownLights = {
   'Busch-Jaeger': {
+    fix: function () {
+      if (this.obj.type === 'On/Off light') {
+        this.log(`Removing brightness for ${this.name}`);
+        this.config.bri = false;
+      }
+    },
     // See: https://www.busch-jaeger.de/en/products/product-solutions/dimmer/busch-radio-controlled-dimmer-zigbee-light-link/
     models: {
       'RM01':                             {}                        // 6715 U-500 with 6736-84


### PR DESCRIPTION
Fixes #241 for my BJ wall switches that don't have a dimming function.