### PR TITLE
Add support for Gira Light Link

### DIFF
--- a/lib/HueSensor.js
+++ b/lib/HueSensor.js
@@ -411,6 +411,23 @@ function HueSensor (accessory, id, obj) {
             }
           }
         }
+      } else if (
+        this.obj.manufacturername === 'Insta' &&
+        this.obj.modelid === 'WS_3f_G_1'
+      ) {
+        // Gira Light Link wall transmitter
+        this.createLabel(Characteristic.ServiceLabelNamespace.ARABIC_NUMERALS)
+        //this.createButton(1, 'Dim down', SINGLE)
+        //this.createButton(2, 'Dim Up', SINGLE)
+        this.createButton(3, 'Button 1', SINGLE)
+        this.createButton(4, 'Button 2', SINGLE)
+        this.createButton(5, 'Button 3', SINGLE)
+        this.createButton(6, 'Button 4', SINGLE)
+        this.type = {
+          key: 'buttonevent',
+          homekitValue: function (v) { return Math.floor(v / 1000) },
+          homekitAction: hkZLLSwitchAction
+        }
       } else {
         this.log.warn(
           '%s: %s: warning: ignoring unknown %s sensor %j',
@@ -1290,7 +1307,7 @@ HueSensor.prototype.checkButtonevent = function (
       buttonevent, this.obj.state.buttonevent
     )
     this.obj.state.buttonevent = buttonevent
-    if (buttonIndex != null && action != null) {
+    if (buttonIndex != null && action != null && this.buttonMap[buttonIndex]) {
       this.log.info(
         '%s: homekit button %s', this.buttonMap[buttonIndex].displayName,
         {0: 'single press', 1: 'double press', 2: 'long press'}[action]


### PR DESCRIPTION
Hey @ebaauw,

I added support for the Gira Light Link wall transmitter (https://www.gira.com/en_GB/gebaeudetechnik/produkte/manuelle_lichtsteuerung/zigbee-lightlink/features.html). I didn't add the topmost buttons as I still use them to directly dimm the light. Feel free to enable them if you want.