### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "BSB001": "1.16.0",
     "BSB002": "1.28.0",
     "deCONZ": "2.5.52",
-    "homebridge": "^0.4.45",
-    "node": "^10.14.2"
+    "homebridge": ">=0.4.45",
+    "node": ">=10.14.2"
   },
   "dependencies": {
     "deferred": "~0.7.9",


### PR DESCRIPTION
Allow recommended version or higher to remove Node version warning.
Current production version gives warning to update even if you are using a Node version later than recommended. Looks like the >= was intended.