### PR TITLE
Add support for SmartThings button

### DIFF
--- a/lib/HueSensor.js
+++ b/lib/HueSensor.js
@@ -678,6 +678,18 @@ function HueSensor (accessory, id, obj) {
           homekitAction: hkZLLSwitchAction
         }
       } else if (
+        this.obj.manufacturername === 'Samjin' &&
+        this.obj.modelid === 'button'
+      ) {
+        // Samsung Smartthings Button
+        this.createLabel(Characteristic.ServiceLabelNamespace.ARABIC_NUMERALS)
+        this.createButton(1, 'Button', SINGLE_DOUBLE_LONG)
+        this.type = {
+          key: 'buttonevent',
+          homekitValue: function (v) { return Math.floor(v / 1000) },
+          homekitAction: hkZLLSwitchAction
+        }
+      } else if (
         this.obj.manufacturername === 'Sunricher' &&
         this.obj.modelid === 'ZG2833K8_EU05'
       ) {
@@ -807,6 +819,11 @@ function HueSensor (accessory, id, obj) {
         (this.obj.modelid === 'TH-H_V15' || this.obj.modelid === 'TH-T_V15')
       ) {
         // Heiman temperature/humidity sensor
+      } else if (
+        this.obj.manufacturername === 'Samjin' &&
+        this.obj.modelid === 'button'
+      ) {
+        // Samsung SmartThings Button temperature sensor
       } else {
         this.log.warn(
           '%s: %s: warning: unknown %s sensor %j',


### PR DESCRIPTION
This adds support for the [SmartThings button](https://www.samsung.com/us/smart-home/smartthings/buttons/samsung-smartthings-button-gp-u999sjvleaa/).

This is a single button supporting single, double, and long press. It also contains a temperature sensor.