### PR TITLE
Add support for controls to step brightness up and down.

### DIFF
--- a/lib/HueLight.js
+++ b/lib/HueLight.js
@@ -486,19 +486,10 @@ function HueLight (accessory, id, obj, type = 'light') {
         .on('set', this.setBri.bind(this))
       this.checkBri(this.obj.state.bri)
 
-      this.service.addOptionalCharacteristic(my.Characteristics.BrightnessUp)
-      this.service.getCharacteristic(my.Characteristics.BrightnessUp)
-        .on('set', this.setBriUp.bind(this))
-
-      this.service.addOptionalCharacteristic(my.Characteristics.BrightnessDown)
-      this.service.getCharacteristic(my.Characteristics.BrightnessDown)
-        .on('set', this.setBriDown.bind(this))
-
-      this.service.addOptionalCharacteristic(my.Characteristics.BrightnessStep)
-      this.hk.briStep = 10
-      this.service.getCharacteristic(my.Characteristics.BrightnessStep)
-        .updateValue(this.hk.briStep)
-        .on('set', this.setBriStep.bind(this))
+      this.service.addOptionalCharacteristic(my.Characteristics.BrightnessChange)
+      this.service.getCharacteristic(my.Characteristics.BrightnessChange)
+        .updateValue(0)
+        .on('set', this.setBriChange.bind(this))
     }
     if (this.config.ct) {
       this.service.addOptionalCharacteristic(Characteristic.ColorTemperature)
@@ -553,6 +544,7 @@ HueLight.prototype.setConfig = function () {
     xy: this.obj.state.xy !== undefined,
     wallSwitch: false,
     outlet: this.bridge.outlet[this.type + 's'][this.id],
+    resetTimeout: this.bridge.platform.config.resetTimeout,
     valve: this.type === 'light' && this.bridge.valve[this.id],
     waitTimeUpdate: this.bridge.platform.config.waitTimeUpdate
   }
@@ -1329,33 +1321,26 @@ HueLight.prototype.setBri = function (bri, callback) {
   })
 }
 
-HueLight.prototype.setBriUp = function (value, callback) {
-  return this.stepBri(true, value, callback)
-}
-
-HueLight.prototype.setBriDown = function (value, callback) {
-  return this.stepBri(false, value, callback)
-}
-
-HueLight.prototype.stepBri = function (up, value, callback) {
-  if (value === false) {
+HueLight.prototype.setBriChange = function (delta, callback) {
+  if (delta === 0) {
     return callback()
   }
 
-  const newValue = up ? Math.min(100.0, this.hk.bri + this.hk.briStep) : Math.max(0.0, this.hk.bri - this.hk.briStep)
-  this.service.setCharacteristic(Characteristic.Brightness, newValue)
-
   setTimeout(() => {
-    const characteristic = up ? my.Characteristics.BrightnessUp : my.Characteristics.BrightnessDown
-    this.service.setCharacteristic(characteristic, false)
-  }, 100)
+    this.service.setCharacteristic(my.Characteristics.BrightnessChange, 0)
+  }, this.config.resetTimeout)
 
-  callback()
-}
-
-HueLight.prototype.setBriStep = function (step, callback) {
-  this.hk.briStep = step
-  callback()
+  this.log.info(
+    '%s: homekit brightness change by %s%%', this.name,
+    delta
+  )
+  const briDelta = Math.round(delta * 254.0 / 100.0)
+  this.request({ bri_inc: briDelta })
+    .then((obj) => {
+      callback()
+    }).catch((err) => {
+      callback(err)
+    })
 }
 
 HueLight.prototype.setCT = function (ct, callback) {

--- a/lib/HueLight.js
+++ b/lib/HueLight.js
@@ -485,6 +485,20 @@ function HueLight (accessory, id, obj, type = 'light') {
       this.service.getCharacteristic(Characteristic.Brightness)
         .on('set', this.setBri.bind(this))
       this.checkBri(this.obj.state.bri)
+
+      this.service.addOptionalCharacteristic(my.Characteristics.BrightnessUp)
+      this.service.getCharacteristic(my.Characteristics.BrightnessUp)
+        .on('set', this.setBriUp.bind(this))
+
+      this.service.addOptionalCharacteristic(my.Characteristics.BrightnessDown)
+      this.service.getCharacteristic(my.Characteristics.BrightnessDown)
+        .on('set', this.setBriDown.bind(this))
+
+      this.service.addOptionalCharacteristic(my.Characteristics.BrightnessStep)
+      this.hk.briStep = 10
+      this.service.getCharacteristic(my.Characteristics.BrightnessStep)
+        .updateValue(this.hk.briStep)
+        .on('set', this.setBriStep.bind(this))
     }
     if (this.config.ct) {
       this.service.addOptionalCharacteristic(Characteristic.ColorTemperature)
@@ -1313,6 +1327,35 @@ HueLight.prototype.setBri = function (bri, callback) {
     this.hk.bri = oldBri
     callback(err)
   })
+}
+
+HueLight.prototype.setBriUp = function (value, callback) {
+  return this.stepBri(true, value, callback)
+}
+
+HueLight.prototype.setBriDown = function (value, callback) {
+  return this.stepBri(false, value, callback)
+}
+
+HueLight.prototype.stepBri = function (up, value, callback) {
+  if (value === false) {
+    return callback()
+  }
+
+  const newValue = up ? Math.min(100.0, this.hk.bri + this.hk.briStep) : Math.max(0.0, this.hk.bri - this.hk.briStep)
+  this.service.setCharacteristic(Characteristic.Brightness, newValue)
+
+  setTimeout(() => {
+    const characteristic = up ? my.Characteristics.BrightnessUp : my.Characteristics.BrightnessDown
+    this.service.setCharacteristic(characteristic, false)
+  }, 100)
+
+  callback()
+}
+
+HueLight.prototype.setBriStep = function (step, callback) {
+  this.hk.briStep = step
+  callback()
 }
 
 HueLight.prototype.setCT = function (ct, callback) {

--- a/lib/HuePlatform.js
+++ b/lib/HuePlatform.js
@@ -68,6 +68,7 @@ function HuePlatform (log, configJson, homebridge) {
     nativeHomeKitLights: true,
     nativeHomeKitSensors: true,
     nupnp: true,
+    resetTimeout: 500,
     resource: true,
     rooms: false,
     rules: false,
@@ -174,6 +175,11 @@ function HuePlatform (log, configJson, homebridge) {
         )
         break
       case 'platform':
+        break
+      case 'resettimeout':
+        this.config.resetTimeout = toIntBetween(
+          value, 10, 2000, this.config.resetTimeout
+        )
         break
       case 'resource':
         this.config.resource = !!value


### PR DESCRIPTION
Adds three controls: brightness step, brightness up, and brightness down. Each time brightness up or down are activated, they increase or decrease the brightness value by the step amount, respectively.

The brightness steppers are intended to be used with dimmer up/down pushbuttons, without requiring that the dimmers be paired directly to the lights.

This is somewhat experimental. I'm curious of your reaction and thoughts on this, @ebaauw. I'm also uncertain about a few points in the implementation, which we can hash out if you're positive on the idea.

The requires some matching changes to homebridge-lib.