### PR TITLE
Add support for newer Heiman smoke sensor

### DIFF
--- a/lib/HueSensor.js
+++ b/lib/HueSensor.js
@@ -1017,7 +1017,9 @@ function HueSensor (accessory, id, obj) {
     case 'ZHAFire':
       if (
         this.obj.manufacturername === 'Heiman' &&
-        (this.obj.modelid === 'SMOK_V16' || this.obj.modelid === 'GAS_V15')
+        (this.obj.modelid === 'SMOK_V16' ||
+         this.obj.modelid === 'GAS_V15' ||
+         this.obj.modelid === 'SmokeSensor-N-3.0')
       ) {
         // Heiman fire sensor
         // Heiman gas sensor


### PR DESCRIPTION
This adds support for a different (newer?) model of the Heiman smoke sensor, with modelid SmokeSensor-N-3.0.