### PR TITLE
Accept Heiman smoke detectors with uppercased manufacturer name

### DIFF
--- a/lib/HueSensor.js
+++ b/lib/HueSensor.js
@@ -1028,7 +1028,8 @@ function HueSensor (accessory, id, obj) {
       break
     case 'ZHAFire':
       if (
-        this.obj.manufacturername === 'Heiman' &&
+        (this.obj.manufacturername === 'Heiman' ||
+         this.obj.manufacturername === 'HEIMAN') &&
         (this.obj.modelid === 'SMOK_V16' ||
          this.obj.modelid === 'GAS_V15' ||
          this.obj.modelid === 'SmokeSensor-N-3.0')


### PR DESCRIPTION
Some units have uppercased HEIMAN, for some reason