### PR TITLE
ignore outlet for SONOFF

### DIFF
--- a/lib/HueLight.js
+++ b/lib/HueLight.js
@@ -204,6 +204,11 @@ const knownLights = {
     }
   },
   ShenZhen_Homa: { // PR #234, issue #235
+  },
+  SONOFF: {
+    models: {
+      BASICZBR3: { fix: function () { this.config.outlet = false } } 
+    }
   }
 }
 


### PR DESCRIPTION
ph outlet -v  will add the SONOFF BASICZBR3 devices to the outlet resourcelink and display them as outlets. As these are not outlets, it should be set to false.