### PR TITLE
Apply nupnp config option.

### DIFF
--- a/lib/HueDiscovery.js
+++ b/lib/HueDiscovery.js
@@ -19,11 +19,13 @@ class HueDiscovery {
     this._debug('constructor(%j)', options)
     this._options = {
       forceHttp: false,
-      timeout: 5
+      timeout: 5,
+      nupnp: true
     }
     const optionParser = new homebridgeLib.OptionParser(this._options)
     optionParser.boolKey('forceHttp')
     optionParser.intKey('timeout', 1, 60)
+    optionParser.boolKey('nupnp')
     optionParser.boolKey('verbose')
     optionParser.parse(options)
     this._debug('constructor(%j) => %j', options, this._options)
@@ -83,6 +85,9 @@ class HueDiscovery {
   }
 
   async _nupnp (name, options) {
+    if (!this._options.nupnp) {
+      return
+    }
     if (this._options.verbose) {
       this.bridgeMap[name] = {}
     }

--- a/lib/HuePlatform.js
+++ b/lib/HuePlatform.js
@@ -257,7 +257,8 @@ function HuePlatform (log, configJson, homebridge) {
   }
   this.hueDiscovery = new HueDiscovery({
     forceHttp: this.config.forceHttp,
-    timeout: this.config.timeout
+    timeout: this.config.timeout,
+    nupnp: this.config.nupnp
   })
   this.bridgeMap = {}
   this.bridges = []


### PR DESCRIPTION
The nupnp config option is ignored at the moment. HueDiscovery::_nupnp(name, options) will now respect it. Fixes Issue #653 .