### PR TITLE
Feature: Allow bridge to be hidden

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -72,6 +72,10 @@
         "description": "Expose lights.",
         "type": "boolean"
       },
+      "hideBridge": {
+        "description": "Do not expose the bridge as an accessory (if true, also disables link button).",
+        "type": "boolean"
+      },
       "linkButton": {
         "description": "Expose the link button on the Hue bridge.",
         "type": "boolean"
@@ -260,6 +264,7 @@
           "condition": { "functionBody": "return model.scenes" }
         },
         "linkButton",
+        "hideBridge",
         "schedules",
         "rules"
       ]

--- a/lib/HueBridge.js
+++ b/lib/HueBridge.js
@@ -232,6 +232,7 @@ HueBridge.prototype.exposeBridge = async function (obj) {
       )
       throw new Error('unknown bridge')
   }
+
   this.infoService = new Service.AccessoryInformation()
   this.serviceList.push(this.infoService)
   this.infoService
@@ -273,6 +274,9 @@ HueBridge.prototype.exposeBridge = async function (obj) {
         axValue: Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS
       })
   }
+
+  if (this.platform.config.hideBridge) { return; }
+  
   this.accessoryList.push(this)
 }
 

--- a/lib/HueBridge.js
+++ b/lib/HueBridge.js
@@ -232,7 +232,6 @@ HueBridge.prototype.exposeBridge = async function (obj) {
       )
       throw new Error('unknown bridge')
   }
-
   this.infoService = new Service.AccessoryInformation()
   this.serviceList.push(this.infoService)
   this.infoService
@@ -276,7 +275,7 @@ HueBridge.prototype.exposeBridge = async function (obj) {
   }
 
   if (this.platform.config.hideBridge) { return; }
-  
+
   this.accessoryList.push(this)
 }
 

--- a/lib/HuePlatform.js
+++ b/lib/HuePlatform.js
@@ -181,6 +181,9 @@ function HuePlatform (log, configJson, homebridge) {
       case 'linkbutton':
         this.config.linkbutton = !!value
         break
+      case 'hidebridge':
+        this.config.hideBridge = !!value
+        break
       case 'lowbattery':
         this.config.lowBattery = toIntBetween(
           value, 0, 100, this.config.lowBattery


### PR DESCRIPTION
Hello!

I've added a new configuration option which allows users to hide the bridge accessory.

This stops it showing up in Home.app, where it cannot be used.