### PR TITLE
Add SAGE Doorbell Sensor support

### DIFF
--- a/lib/HueSensor.js
+++ b/lib/HueSensor.js
@@ -847,6 +847,18 @@ function HueSensor (accessory, id, obj) {
           homekitValue: function (v) { return Math.floor(v / 1000) },
           homekitAction: hkZLLSwitchAction
         }
+      } else if (
+        this.obj.manufacturername === 'Echostar' &&
+        this.obj.modelid === 'Bell'
+      ) {
+        this.createLabel(Characteristic.ServiceLabelNamespace.ARABIC_NUMERALS)
+        this.createButton(1, 'Front Doorbell', SINGLE)
+        this.createButton(2, 'Rear Doorbell', SINGLE)
+        this.type = {
+          key: 'buttonevent',
+          homekitValue: function (v) { return Math.floor(v / 1000) },
+          homekitAction: hkZLLSwitchAction
+        }
       } else {
         this.log.warn(
           '%s: %s: warning: ignoring unknown %s sensor %j',


### PR DESCRIPTION
Verified by pairing with deconz 2.05.80, connected to a 12v doorbell.

This will generate multiple events if someone keeps the doorbell pressed.