### PR TITLE
Add support for Aqara D1 single key wireless wall switch (WXKG06LM)

### DIFF
--- a/lib/HueSensor.js
+++ b/lib/HueSensor.js
@@ -546,7 +546,8 @@ function HueSensor (accessory, id, obj) {
       } else if (
         this.obj.manufacturername === 'LUMI' && (
           this.obj.modelid === 'lumi.remote.b1acn01' ||
-          this.obj.modelid === 'lumi.remote.b186acn01'
+          this.obj.modelid === 'lumi.remote.b186acn01' ||
+          this.obj.modelid === 'lumi.remote.b186acn02'
         )
       ) {
         this.createLabel(Characteristic.ServiceLabelNamespace.ARABIC_NUMERALS)


### PR DESCRIPTION
I got this device a couple of months ago. Deconz registers it correctly but homebridge-hue plugin is not recognizing it.

I got this warning on homebridge startup when the first time I have tried it:

```
ignoring unknown ZHASwitch sensor 
{
    "config": {
        "battery": 100,
        "on": true,
        "reachable": true,
        "temperature": 2900
    },
    "ep": 1,
    "etag": "e834d1aa588c9995224ea3c7525e2ee5",
    "lastseen": "2020-10-01T14:48Z",
    "manufacturername": "LUMI",
    "mode": 1,
    "modelid": "lumi.remote.b186acn02",
    "name": "Transmitter 1-gang",
    "state": {
        "buttonevent": 1002,
        "lastupdated": "2020-10-01T13:58:31.815"
    },
    "swversion": "20190329",
    "type": "ZHASwitch",
    "uniqueid": "00:15:8d:00:04:1b:52:41-01-0012"
}
```

After applying the patch, it works perfectly.

[
![issue](https://user-images.githubusercontent.com/72460/94826787-f6fd2700-0407-11eb-8116-4ecc0e7c0aa8.jpeg)
](url)





