### PR TITLE
Add support for Aqara D1 double key wireless wall switch (WXKG07LM)

### DIFF
--- a/lib/HueSensor.js
+++ b/lib/HueSensor.js
@@ -558,8 +558,10 @@ function HueSensor (accessory, id, obj) {
           homekitAction: hkZLLSwitchAction
         }
       } else if (
-        this.obj.manufacturername === 'LUMI' &&
-        this.obj.modelid === 'lumi.remote.b286acn01'
+        this.obj.manufacturername === 'LUMI' && (
+          this.obj.modelid === 'lumi.remote.b286acn01' ||
+          this.obj.modelid === 'lumi.remote.b286acn02'
+        )
       ) {
         this.createLabel(Characteristic.ServiceLabelNamespace.ARABIC_NUMERALS)
         this.createButton(1, 'Left', SINGLE_DOUBLE_LONG)


### PR DESCRIPTION
This does the same as #774 but for the double rocker switch from the same series.