### PR TITLE
Add support for Xiaomi Mi light intensity sensor (lumi.sen_ill.mgl01)

### DIFF
--- a/lib/HueSensor.js
+++ b/lib/HueSensor.js
@@ -1025,6 +1025,11 @@ function HueSensor (accessory, id, obj) {
         this.obj.modelid === 'lumi.sensor_motion.aq2'
       ) {
         // Xiaomi Aqara motion sensor
+      } else if (
+        this.obj.manufacturername === 'LUMI' &&
+        this.obj.modelid === 'lumi.sen_ill.mgl01'
+      ) {
+        // Xiaomi Mi light intensity sensor
       } else {
         this.log.warn(
           '%s: %s: warning: unknown %s sensor %j',


### PR DESCRIPTION
Just adding a case with the model name. Works largely like the combined motion + light sensors, except that there is no motion reported.