### PR TITLE
Fix for Aqara Cube drop and shake

### DIFF
--- a/lib/HueSensor.js
+++ b/lib/HueSensor.js
@@ -592,7 +592,7 @@ function HueSensor (accessory, id, obj) {
             homekitAction: function (v) {
               if (v % 1000 === 0) {
                 return Characteristic.ProgrammableSwitchEvent.LONG_PRESS
-              } else if (v % 1000 === Math.floor(v / 1000) || v % 1000 === 8) {
+              } else if (v % 1000 === Math.floor(v / 1000) || v % 1000 === 7) {
                 return Characteristic.ProgrammableSwitchEvent.DOUBLE_PRESS
               } else {
                 return Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS

--- a/lib/HueSensor.js
+++ b/lib/HueSensor.js
@@ -591,11 +591,11 @@ function HueSensor (accessory, id, obj) {
             homekitValue: function (v) { return Math.floor(v / 1000) },
             homekitAction: function (v) {
               if (v % 1000 === 0) {
-                return Characteristic.ProgrammableSwitchEvent.LONG_PRESS
-              } else if (v % 1000 === Math.floor(v / 1000) || v % 1000 === 7) {
-                return Characteristic.ProgrammableSwitchEvent.DOUBLE_PRESS
-              } else {
                 return Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS
+              } else if (v % 1000 === Math.floor(v / 1000) || v % 1000 === 7) {
+                return Characteristic.ProgrammableSwitchEvent.LONG_PRESS
+              } else {
+                return Characteristic.ProgrammableSwitchEvent.DOUBLE_PRESS
               }
             }
           }


### PR DESCRIPTION
Noticed that cube drop and cube shake were giving the same behaviour, and wakeup was mapped to long press.

With this fix, 7007 is passed as long, 7008 as double and 7000 (wakeup) as single, as they should.