### PR TITLE
Add TRADFRI E14 WS 600lm To Whitelist

### DIFF
--- a/lib/HueLight.js
+++ b/lib/HueLight.js
@@ -135,6 +135,7 @@ const knownLights = {
       'TRADFRI bulb E12 WS2 opal 600lm': { noTransition: true },
       'TRADFRI bulb E14 WS opal 400lm': { noTransition: true },
       'TRADFRI bulb E14 WS 470lm': { noTransition: true },
+      'TRADFRI bulb E14 WS opal 600lm': { noTransition: true },
       'TRADFRI bulb E27 CWS opal 600lm': { noTransition: true },
       'TRADFRI bulb E27 WS opal 980lm': { noTransition: true },
       'TRADFRI bulb E27 WS�opal 980lm': { noTransition: true },


### PR DESCRIPTION
Add the tradfri bulb with the name 'TRADFRI bulb E14 WS opal 600lm' to
the whitelist:
- HomeKit Adaptive Lighting didn't work with my 600lm WS bulb, but did
  with the 400lm version (which is already on the whitelist)
- adding the 600lm version to the whitelist fixes this issue; the
  temperature is adjusted when modifying the brightness and brightness
  doesn't get stuck when using the Adaptive Lighting color in HomeKit
  (which it did before)

Thanks for all the work and effort you put into this project 👍 

Signed-off-by: ahahn94 <ahahn94@outlook.com>