### PR TITLE
Option for disabling light effects

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -240,6 +240,10 @@
           "key": "nativeHomeKitLights",
           "condition": { "functionBody": "return model.lights" }
         },
+        {
+          "key": "excludeEffects",
+          "condition": { "functionBody": "return model.lights" }
+        },
         "groups",
         {
           "key": "group0",

--- a/config.schema.json
+++ b/config.schema.json
@@ -33,7 +33,7 @@
         }
       },
       "excludeEffects": {
-        "description": "Disable light effects exposure",
+        "description": "Don't expose light effects if available",
         "type": "boolean"
       },
       "forceEveWeather": {

--- a/config.schema.json
+++ b/config.schema.json
@@ -32,6 +32,10 @@
           "type": "string"
         }
       },
+      "excludeEffects": {
+        "description": "Disable light effects exposure",
+        "type": "boolean"
+      },
       "forceEveWeather": {
         "description": "Create dummy pressure sensor for temperature/humidity sensors, so the Eve app treats them like an Eve Weather.",
         "type": "boolean"

--- a/lib/HueAccessory.js
+++ b/lib/HueAccessory.js
@@ -238,8 +238,10 @@ HueAccessory.prototype.exposeLightResource = function (id, obj) {
     this.bridge.lights[id] = light
     this.lights[id] = light
     this.serviceList.push(light.service)
-    for (const service of light.effectServices) {
-      this.serviceList.push(service)
+    if (!this.bridge.platform.config.excludeEffects) {
+      for (const service of light.effectServices) {
+        this.serviceList.push(service)
+      }
     }
     this.resource = this.resource || light
     this.service = this.service || light.service

--- a/lib/HuePlatform.js
+++ b/lib/HuePlatform.js
@@ -73,8 +73,8 @@ function HuePlatform (log, configJson, homebridge) {
   this.config = {
     anyOn: true,
     brightnessAdjustment: 1,
-    excludeSensorTypes: {},
     excludeEffects: false,
+    excludeSensorTypes: {},
     forceHttp: false,
     groups: false,
     group0: false,
@@ -107,6 +107,9 @@ function HuePlatform (log, configJson, homebridge) {
         this.config.brightnessAdjustment = toIntBetween(
           value, 10, 100, 100
         ) / 100
+        break
+      case 'excludeEffects':
+        this.config.excludeEffects = !!value
         break
       case 'excludesensortypes':
         if (Array.isArray(value)) {

--- a/lib/HuePlatform.js
+++ b/lib/HuePlatform.js
@@ -108,7 +108,7 @@ function HuePlatform (log, configJson, homebridge) {
           value, 10, 100, 100
         ) / 100
         break
-      case 'excludeEffects':
+      case 'excludeeffects':
         this.config.excludeEffects = !!value
         break
       case 'excludesensortypes':

--- a/lib/HuePlatform.js
+++ b/lib/HuePlatform.js
@@ -74,6 +74,7 @@ function HuePlatform (log, configJson, homebridge) {
     anyOn: true,
     brightnessAdjustment: 1,
     excludeSensorTypes: {},
+    excludeEffects: false,
     forceHttp: false,
     groups: false,
     group0: false,


### PR DESCRIPTION
With the new possibility for light effects my home was spammed with many effect buttons as I have multiple müller lights and I don't want to use this feature.
So I've added an option for disabling exposure of light effects. Default behavior is still yours.