### PR TITLE
Changed to debug level for ProgramData

### DIFF
--- a/lib/HueSensor.js
+++ b/lib/HueSensor.js
@@ -3197,7 +3197,7 @@ HueSensor.prototype.getProgramData = function (callback) {
   buffer[offset++] = 0xFF
 
   buffer = buffer.slice(0, offset)
-  this.log.info(
+  this.log.debug(
     '%s: get homekit program data return %s', this.name, buffer.toString('hex')
   )
   return callback(null, buffer.toString('base64'))


### PR DESCRIPTION
Would it be possible to change the log level from info to debug? I have a lot of these in the homebridge log and it looks debug level would be more appropriate.

As I'm a bit curious, what is this ProgramData used for?