### PR TITLE
Added correct color temperature support for E12-N1E Sengled Bulb

### DIFF
--- a/lib/HueLight.js
+++ b/lib/HueLight.js
@@ -212,6 +212,15 @@ const knownLights = {
   },
   ShenZhen_Homa: { // PR #234, issue #235
   },
+  'sengled': {
+    models: {
+      'E12-N1E': {
+        fix: function () {
+          this.config.ct = true
+        }
+      }
+    }
+  },
   'Signify Netherlands B.V.': {
     // See: http://www.developers.meethue.com/documentation/supported-lights
     gamuts: { // Color gamut per light model.


### PR DESCRIPTION
E12-N1E bulb by Sengled previously failed to enumerate color temperature attribute even though the bulb is ct capable. This fix allows the bulb's color temperature to be correctly controlled (although existing bulbs must be removed and re-added in Deconz). 