### PR TITLE
Add Per-Light Settings for Maximum Brightness Adjustment

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -326,15 +326,6 @@
             "functionBody": "return model.sensors"
           }
         },
-        {
-          "type": "fieldset",
-          "expandable": true,
-          "title": "Light Brightness Limits",
-          "description": "Set brightness limits for specific lights by their serial number.",
-          "items": [
-            "lightSettings"
-          ]
-        },
         "lights",
         {
           "key": "nativeHomeKitLights",
@@ -411,6 +402,15 @@
       "title": "Advanced Settings",
       "description": "Don't change these, unless you understand what you're doing.",
       "items": [
+        {
+          "type": "fieldset",
+          "expandable": true,
+          "title": "Light Brightness Limits",
+          "description": "Set brightness limits for specific lights by their serial number.",
+          "items": [
+            "lightSettings"
+          ]
+        },
         {
           "key": "brightnessAdjustment",
           "condition": {

--- a/config.schema.json
+++ b/config.schema.json
@@ -399,47 +399,26 @@
     {
       "type": "fieldset",
       "expandable": true,
-      "title": "Advanced Settings",
-      "description": "Don't change these, unless you understand what you're doing.",
+      "title": "Light Brightness Limits",
+      "description": "Define brightness limits for specific lights using their serial numbers.",
       "items": [
         {
-          "type": "fieldset",
-          "expandable": true,
-          "title": "Light Brightness Limits",
-          "description": "Set brightness limits for specific lights by their serial number.",
+          "key": "lightSettings",
+          "type": "array",
+          "addButtonTitle": "Add Light Limit",
           "items": [
-            "lightSettings"
+            {
+              "key": "lightSettings[].serialNumber",
+              "title": "Serial Number",
+              "description": "Enter the unique serial number of the light."
+            },
+            {
+              "key": "lightSettings[].limit",
+              "title": "Brightness Limit (%)",
+              "description": "Enter the maximum brightness percentage (1-100)."
+            }
           ]
-        },
-        {
-          "key": "brightnessAdjustment",
-          "condition": {
-            "functionBody": "return model.lights"
-          }
-        },
-        "configuredName",
-        "forceHttp",
-        "heartrate",
-        {
-          "key": "noResponse",
-          "condition": {
-            "functionBody": "return model.lights"
-          }
-        },
-        "ownResourcelinks",
-        "parallelRequests",
-        "resetTimeout",
-        "stealth",
-        "timeout",
-        "waitTimePut",
-        {
-          "key": "waitTimePutGroup",
-          "condition": {
-            "functionBody": "return model.groups"
-          }
-        },
-        "waitTimeResend",
-        "waitTimeUpdate"
+        }
       ]
     }
   ]

--- a/config.schema.json
+++ b/config.schema.json
@@ -75,6 +75,32 @@
         "description": "ID of the Homebridge Hue2 migration resource link.",
         "type": "string"
       },
+      "lightSettings": {
+        "type": "array",
+        "title": "Light Settings",
+        "description": "Define limits for brightness using the light's serial number.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "serialNumber": {
+              "type": "string",
+              "title": "Serial Number",
+              "description": "The serial number of the light."
+            },
+            "limit": {
+              "type": "integer",
+              "title": "Brightness Limit (%)",
+              "description": "The maximum brightness allowed (1-100%).",
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          "required": [
+            "serialNumber",
+            "limit"
+          ]
+        }
+      },
       "lights": {
         "description": "Expose lights.",
         "type": "boolean"
@@ -299,6 +325,15 @@
           "condition": {
             "functionBody": "return model.sensors"
           }
+        },
+        {
+          "type": "fieldset",
+          "expandable": true,
+          "title": "Light Brightness Limits",
+          "description": "Set brightness limits for specific lights by their serial number.",
+          "items": [
+            "lightSettings"
+          ]
         },
         "lights",
         {

--- a/lib/HueLight.js
+++ b/lib/HueLight.js
@@ -1170,41 +1170,78 @@ class HueLight {
     // if (bri === this.hk.bri) {
     //   return callback()
     // }
+    const lightConfig = this.bridge.platform.config.lightSettings.find(
+        (setting) => setting.serialNumber === this.serialNumber
+    );
+
+    const originalBri = bri; // Store original brightness for logging.
+
+    if (lightConfig && lightConfig.limit) {
+      const maxBrightness = lightConfig.limit;
+      bri = Math.round((bri * maxBrightness) / 100);
+      this.log.info(
+          '%s: Adjusting brightness from %s%% to %s%% of limit (%s%%)',
+          this.name,
+          originalBri,
+          bri,
+          maxBrightness
+      );
+    }
+
     this.log.info(
-      '%s: homekit brightness changed from %s%% to %s%%', this.name,
-      this.hk.bri, bri
-    )
-    const oldBri = this.hk.bri
-    this.hk.bri = bri
-    this.checkAdaptiveLighting()
-    const newBri = Math.round(this.hk.bri * 254.0 / 100.0)
-    this.put({ bri: newBri }).then(() => {
-      this.obj.state.bri = newBri
-      callback()
-    }).catch((error) => {
-      this.hk.bri = oldBri
-      callback(error)
-    })
+        '%s: homekit brightness changed from %s%% to %s%%',
+        this.name,
+        this.hk.bri,
+        bri
+    );
+    const oldBri = this.hk.bri;
+    this.hk.bri = bri;
+    this.checkAdaptiveLighting();
+    const newBri = Math.round(this.hk.bri * 254.0 / 100.0);
+    this.put({ bri: newBri })
+        .then(() => {
+          this.obj.state.bri = newBri;
+          callback();
+        })
+        .catch((error) => {
+          this.hk.bri = oldBri;
+          callback(error);
+        });
   }
 
   setBriChange (delta, callback) {
-    delta = Math.round(delta)
-    if (delta === 0) {
-      return callback()
+    const lightConfig = this.bridge.platform.config.lightSettings.find(
+        (setting) => setting.serialNumber === this.serialNumber
+    );
+
+    if (lightConfig && lightConfig.limit) {
+      const maxBrightness = lightConfig.limit;
+      delta = Math.round((delta * maxBrightness) / 100);
+      this.log.info(
+          '%s: Adjusting brightness change by %s%% of limit (%s%%)',
+          this.name,
+          delta,
+          maxBrightness
+      );
     }
-    this.log.info(
-      '%s: homekit brightness change by %s%%', this.name,
-      delta
-    )
-    const briDelta = Math.round(delta * 254.0 / 100.0)
-    this.put({ bri_inc: briDelta }).then((obj) => {
-      setTimeout(() => {
-        this.service.setCharacteristic(my.Characteristics.BrightnessChange, 0)
-      }, this.config.resetTimeout)
-      callback()
-    }).catch((error) => {
-      callback(error)
-    })
+
+    delta = Math.round(delta);
+    if (delta === 0) {
+      return callback();
+    }
+
+    this.log.info('%s: homekit brightness change by %s%%', this.name, delta);
+    const briDelta = Math.round(delta * 254.0 / 100.0);
+    this.put({ bri_inc: briDelta })
+        .then(() => {
+          setTimeout(() => {
+            this.service.setCharacteristic(my.Characteristics.BrightnessChange, 0);
+          }, this.config.resetTimeout);
+          callback();
+        })
+        .catch((error) => {
+          callback(error);
+        });
   }
 
   setCt (ct, callback) {

--- a/lib/HuePlatform.js
+++ b/lib/HuePlatform.js
@@ -100,6 +100,7 @@ class HuePlatform {
       .boolKey('hueDimmerRepeat')
       .boolKey('hueMotionTemperatureHistory')
       .stringKey('homebridgeHue2')
+      .arrayKey('lightSettings')
       .boolKey('lights')
       .boolKey('lightSensors')
       .boolKey('linkButton')
@@ -142,6 +143,7 @@ class HuePlatform {
           }
         }
       }
+      this.config.lightSettings = this.config.lightSettings || [];
       this.config.brightnessAdjustment /= 100
       const excludeSensorTypes = this.config.excludeSensorTypes
       this.config.excludeSensorTypes = {}


### PR DESCRIPTION
This update introduces a new configuration option called Light Settings. It allows users to set a maximum brightness percentage for individual lights based on their serial numbers.

Details:
- Configuration:
   - The Light Settings option accepts an array of objects, each containing:
      - serialNumber: The unique serial number of the light.
      - limit: The maximum brightness percentage (1-100%).
   - Brightness is dynamically adjusted in HomeKit based on the defined limit.
- Example Behavior:
   - If a light has a maximum brightness limit of 70%:
      - Setting HomeKit brightness to 100% adjusts the light to 70%.
      - Setting HomeKit brightness to 50% adjusts the light to 35%.

Use Case:
This feature is particularly useful for scenarios where certain lights have power or brightness constraints. For instance:

A Philips light on an oven hood with a 4W limit can be safely used by setting its maximum brightness to 70%.
Example Configuration:
```
"lightSettings": [
  {
    "serialNumber": "001788102201",
    "limit": 70
  },
  {
    "serialNumber": "001788102202",
    "limit": 50
  }
]
```

Why This Change?
This enhancement provides finer control over individual lights, improving both usability and safety. It ensures that lights with specific hardware limitations can function optimally without manual intervention.