### PR TITLE
feat(sensor): add support for Hue Smart Button (v2) → RDM005

### DIFF
--- a/lib/HueSensor.js
+++ b/lib/HueSensor.js
@@ -185,6 +185,7 @@ class HueSensor {
                 break
               case 'ROM001': // Hue smart button
               case 'RDM003': // Hue smart button
+              case 'RDM005': // Hue smart button (v2)
                 this.createButton(1, 'Button', events)
                 if (repeat) this.repeat = [1]
                 break


### PR DESCRIPTION
Dear ebaauw,

I’m aware that you’re currently in a feature freeze. However, this is a very minor addition, and I believe it will be greatly appreciated by users who have purchased the new second-generation Hue Smart Button (RDM005).

Thank you very much for your continued work and maintenance of this excellent plugin.

Best regards,
Markus